### PR TITLE
Fix: error when video is missing

### DIFF
--- a/src/libs/directus/util.ts
+++ b/src/libs/directus/util.ts
@@ -15,8 +15,8 @@ const mapMediaSource = <
       ...item,
       item: {
         ...item.item,
-        embed_code: item.item.embed_code ?? null,
-        video: item.item.video
+        embed_code: item.item?.embed_code ?? null,
+        video: item.item?.video
           ? {
               ...item.item.video,
               src: `${process.env.DIRECTUS_URL}/assets/${item.item.video.id}`,


### PR DESCRIPTION
An error occurred when the video used in a project item was directly deleted from the media library.